### PR TITLE
Add build test actions for Ubuntu and macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CMake
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependecies
+      run: sudo apt-get install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
+      
+    - name: Try compilation
+      run: |
+         "${GITHUB_WORKSPACE}/Build.sh"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  build_ubuntu:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
@@ -29,3 +29,27 @@ jobs:
     - name: Try compilation
       run: |
          "${GITHUB_WORKSPACE}/Build.sh"
+         
+         
+  build_mac:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install GitHub CLI
+        run: |
+          brew update
+          brew install gh
+      - name: Install dependencies
+        run: |
+          brew install brew install cmake eigen glew pkgconfig freeglut opencv
+          
+      - name: link opencv
+        run: |
+          brew link --overwrite opencv
+          
+      - name: Try compilation
+        run: |
+           "${GITHUB_WORKSPACE}/Build.sh"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install dependecies
-      run: sudo apt update
-           sudo apt install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
+      run: sudo apt-get update
+           sudo apt-get install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
       
     - name: Try compilation
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install dependecies
-      run: sudo apt-get install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
+      run: sudo apt update
+           sudo apt install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
       
     - name: Try compilation
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           brew install gh
       - name: Install dependencies
         run: |
-          brew install brew install cmake eigen glew pkgconfig freeglut opencv
+          brew install cmake eigen glew pkgconfig freeglut opencv
           
       - name: link opencv
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install dependecies
+    - name: Update apt list
       run: sudo apt-get update
-           sudo apt-get install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
+      
+    - name: Install dependecies
+      run: sudo apt-get install cmake build-essential libeigen3-dev libboost-dev libopencv-dev libglew-dev
       
     - name: Try compilation
       run: |

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -6,49 +6,75 @@ on:
   pull_request:
     branches: [ main ]
 
+# actions.yaml
+#
+# In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).
 env:
-  # Path to the solution file relative to the root of the project.
-  SOLUTION_FILE_PATH: .
-
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
 jobs:
   build:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - name: add submodules
+        run: git submodule add https://github.com/Microsoft/vcpkg
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
-    - name: Install packages and dependencies
-      run: |
-        bootstrap-vcpkg
-        vcpkg install opencv boost eigen3 glew
-        
-    - name: set VCPKG_ROOT
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-        # Add additional options to the MSBuild command line here (like platform or verbosity level).
-        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      shell: pwsh
-      run: setx VCPKG_ROOT C:\vcpkg\ /m
-    
-    - name: set VCPKG_DEFAULT_TRIPLET
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      shell: pwsh
-      run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+      # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
+      - name: 'Setup NuGet Credentials'
+        shell: 'bash'
+        # Replace <OWNER> with your organization name
+        run: >
+          ./vcpkg/vcpkg fetch nuget | tail -n 1
+          sources add
+          -source "https://nuget.pkg.github.com/<OWNER>/index.json"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "<OWNER>"
+          -password "${{ secrets.GITHUB_TOKEN }}"
 
-    
-    
-    - name: Build through Run bat script on PowerShell
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      shell: pwsh
-      run: .\Build.bat 
+      # Omit this step if you're using manifests
+      - name: 'vcpkg package restore'
+        shell: 'bash'
+        run: >
+          ./vcpkg/vcpkg install opencv boost eigen3 glew --triplet ${{ matrix.triplet }}
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+
+        # - name: Build through Run bat script on PowerShell
+        # working-directory: ${{env.GITHUB_WORKSPACE}}
+        # # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        # shell: pwsh
+        # run: setx MACHINE Brand1 /m
+        # - name: Install packages and dependencies
+        #   run: |
+        #     bootstrap-vcpkg
+        #     vcpkg install opencv boost eigen3 glew
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: setx VCPKG_ROOT C:\vcpkg\ /m
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: .\Build.bat 
+
+

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -26,15 +26,13 @@ jobs:
       
     - name: set VCPKG_ROOT
       working-directory: ${{env.GITHUB_WORKSPACE}}
-        # Add additional options to the MSBuild command line here (like platform or verbosity level).
-        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+
       shell: pwsh
       run: setx VCPKG_ROOT C:\vcpkg\ /m
 
     - name: set VCPKG_DEFAULT_TRIPLET
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+
       shell: pwsh
       run: setx VCPKG_DEFAULT_TRIPLET x64-system /m
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,80 +1,53 @@
 name: MSBuild
-
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
 
-# actions.yaml
-#
-# In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).
 env:
-  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
 
 jobs:
   build:
     runs-on: windows-latest
 
     steps:
-      - name: add submodules
-        run: git submodule add https://github.com/Microsoft/vcpkg
+    - uses: actions/checkout@v3
 
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
 
-      # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
-      - name: 'Setup NuGet Credentials'
-        shell: 'bash'
-        # Replace <OWNER> with your organization name
-        run: >
-          ./vcpkg/vcpkg fetch nuget | tail -n 1
-          sources add
-          -source "https://nuget.pkg.github.com/<OWNER>/index.json"
-          -storepasswordincleartext
-          -name "GitHub"
-          -username "<OWNER>"
-          -password "${{ secrets.GITHUB_TOKEN }}"
+    - name: Install packages and dependencies
+      run: |
+        bootstrap-vcpkg
+        vcpkg install opencv boost eigen3 glew
+        
+    - name: set VCPKG_ROOT
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+        # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: setx VCPKG_ROOT C:\vcpkg\ /m
 
-      # Omit this step if you're using manifests
-      - name: 'vcpkg package restore'
-        shell: 'bash'
-        run: >
-          ./vcpkg/vcpkg install opencv boost eigen3 glew --triplet ${{ matrix.triplet }}
-
-      - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-
-        # - name: Build through Run bat script on PowerShell
-        # working-directory: ${{env.GITHUB_WORKSPACE}}
-        # # Add additional options to the MSBuild command line here (like platform or verbosity level).
-        # # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-        # shell: pwsh
-        # run: setx MACHINE Brand1 /m
-        # - name: Install packages and dependencies
-        #   run: |
-        #     bootstrap-vcpkg
-        #     vcpkg install opencv boost eigen3 glew
-
-      - name: Build through Run bat script on PowerShell
-        working-directory: ${{env.GITHUB_WORKSPACE}}
-          # Add additional options to the MSBuild command line here (like platform or verbosity level).
-          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-        shell: pwsh
-        run: setx VCPKG_ROOT C:\vcpkg\ /m
-
-      - name: Build through Run bat script on PowerShell
-        working-directory: ${{env.GITHUB_WORKSPACE}}
-          # Add additional options to the MSBuild command line here (like platform or verbosity level).
-          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-        shell: pwsh
-        run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
-
-      - name: Build through Run bat script on PowerShell
-        working-directory: ${{env.GITHUB_WORKSPACE}}
-          # Add additional options to the MSBuild command line here (like platform or verbosity level).
-          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-        shell: pwsh
-        run: .\Build.bat 
+    - name: set VCPKG_DEFAULT_TRIPLET
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
 
 
+
+    - name: Build through Run bat script on PowerShell
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: .\Build.bat 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -29,7 +29,23 @@ jobs:
       run: |
         bootstrap-vcpkg
         vcpkg install opencv boost eigen3 glew
+        
+    - name: set VCPKG_ROOT
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+        # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: setx VCPKG_ROOT C:\vcpkg\ /m
+    
+    - name: set VCPKG_DEFAULT_TRIPLET
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
 
+    
+    
     - name: Build through Run bat script on PowerShell
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -23,12 +23,7 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
-
-    - name: Install packages and dependencies
-      run: |
-        bootstrap-vcpkg
-        vcpkg install opencv boost eigen3 glew
-        
+      
     - name: set VCPKG_ROOT
       working-directory: ${{env.GITHUB_WORKSPACE}}
         # Add additional options to the MSBuild command line here (like platform or verbosity level).
@@ -41,7 +36,14 @@ jobs:
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       shell: pwsh
-      run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+      run: setx VCPKG_DEFAULT_TRIPLET x64-system /m
+
+
+    - name: Install packages and dependencies
+      run: |
+        bootstrap-vcpkg
+        vcpkg install opencv boost eigen3 glew
+        
 
 
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,38 @@
+name: MSBuild
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Install packages and dependencies
+      run: |
+        bootstrap-vcpkg
+        vcpkg install opencv boost eigen3 glew
+
+    - name: Build through Run bat script on PowerShell
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      shell: pwsh
+      run: .\Build.bat 

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -22,10 +22,13 @@ jobs:
     steps:
       - name: add submodules
         working-directory: ${{env.GITHUB_WORKSPACE}}
-        run: git submodule add https://github.com/Microsoft/vcpkg
+        run: git clone  --recursive https://github.com/Microsoft/vcpkg
+        
+      - name: boostrap submodules
+        run:  ./vcpkg/bootstrap-vcpkg
 
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+#       - name: Checkout submodules
+#         run: git submodule update --init --recursive
 
       # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
       - name: 'Setup NuGet Credentials'
@@ -70,7 +73,7 @@ jobs:
           # Add additional options to the MSBuild command line here (like platform or verbosity level).
           # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
         shell: pwsh
-        run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+        run: setx VCPKG_DEFAULT_TRIPLET x64-system /m
 
       - name: Build through Run bat script on PowerShell
         working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,95 @@
+
+name: nuget
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# actions.yaml
+#
+# In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).
+env:
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: add submodules
+        run: git submodule add https://github.com/Microsoft/vcpkg
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
+      - name: 'Setup NuGet Credentials'
+        shell: 'bash'
+        # Replace <OWNER> with your organization name
+        run: >
+          ./vcpkg/vcpkg fetch nuget | tail -n 1
+          sources add
+          -source "https://nuget.pkg.github.com/<OWNER>/index.json"
+          -storepasswordincleartext
+          -name "GitHub"
+          -username "<OWNER>"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+      # Omit this step if you're using manifests
+      - name: 'vcpkg package restore'
+        shell: 'bash'
+        run: >
+          ./vcpkg/vcpkg install opencv boost eigen3 glew --triplet ${{ matrix.triplet }}
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+
+        # - name: Build through Run bat script on PowerShell
+        # working-directory: ${{env.GITHUB_WORKSPACE}}
+        # # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        # shell: pwsh
+        # run: setx MACHINE Brand1 /m
+        # - name: Install packages and dependencies
+        #   run: |
+        #     bootstrap-vcpkg
+        #     vcpkg install opencv boost eigen3 glew
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: setx VCPKG_ROOT C:\vcpkg\ /m
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+
+      - name: Build through Run bat script on PowerShell
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+          # Add additional options to the MSBuild command line here (like platform or verbosity level).
+          # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        shell: pwsh
+        run: .\Build.bat 
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,6 +21,7 @@ jobs:
 
     steps:
       - name: add submodules
+        working-directory: ${{env.GITHUB_WORKSPACE}}
         run: git submodule add https://github.com/Microsoft/vcpkg
 
       - name: Checkout submodules

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -12,6 +12,8 @@ on:
 # In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).
 env:
   VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+  SOLUTION_FILE_PATH: .
+  BUILD_CONFIGURATION: Release
 
 jobs:
   build:
@@ -75,21 +77,3 @@ jobs:
           # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
         shell: pwsh
         run: .\Build.bat 
-
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,24 +5,22 @@ env:
   VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
 matrix:
-  os: ['windows-2019']
+  os: ['windows-2019', 'ubuntu-20.04']
   include:
     - os: 'windows-2019'
       triplet: 'x86-windows'
       mono: ''
+    - os: 'ubuntu-20.04'
+      triplet: 'x64-linux'
+      # To run `nuget.exe` on non-Windows platforms, we must use `mono`.
+      mono: 'mono'
 
 steps:
-
-
-  - name: add submodules
-    run: git submodule add https://github.com/Microsoft/vcpkg
-  - name: Checkout submodules
-    run: git submodule update --init --recursive
   # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
   - name: 'Setup NuGet Credentials'
     shell: 'bash'
     # Replace <OWNER> with your organization name
-    run: 
+    run: >
       ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
       sources add
       -source "https://nuget.pkg.github.com/<OWNER>/index.json"
@@ -34,40 +32,5 @@ steps:
   # Omit this step if you're using manifests
   - name: 'vcpkg package restore'
     shell: 'bash'
-    run: 
-      ./vcpkg/vcpkg install opencv boost eigen3 glew --triplet ${{ matrix.triplet }}
-
-  - name: Add MSBuild to PATH
-    uses: microsoft/setup-msbuild@v1.0.2
-      
-    # - name: Build through Run bat script on PowerShell
-    # working-directory: ${{env.GITHUB_WORKSPACE}}
-    # # Add additional options to the MSBuild command line here (like platform or verbosity level).
-    # # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-    # shell: pwsh
-    # run: setx MACHINE Brand1 /m
-    # - name: Install packages and dependencies
-    #   run: |
-    #     bootstrap-vcpkg
-    #     vcpkg install opencv boost eigen3 glew
-
-  - name: set through PowerShell
-    working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-    shell: pwsh
-    run: setx VCPKG_ROOT C:\vcpkg\ /m
-    
-  - name: set on PowerShell
-    working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-    shell: pwsh
-    run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
-    
-  - name: Build through Run bat script on PowerShell
-    working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-    shell: pwsh
-    run: .\Build.bat 
+    run: >
+      ./vcpkg/vcpkg install sqlite3 cpprestsdk --triplet ${{ matrix.triplet }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,73 @@
+# actions.yaml
+#
+# In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).
+env:
+  VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+
+matrix:
+  os: ['windows-2019']
+  include:
+    - os: 'windows-2019'
+      triplet: 'x86-windows'
+      mono: ''
+
+steps:
+
+
+  - name: add submodules
+    run: git submodule add https://github.com/Microsoft/vcpkg
+  - name: Checkout submodules
+    run: git submodule update --init --recursive
+  # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
+  - name: 'Setup NuGet Credentials'
+    shell: 'bash'
+    # Replace <OWNER> with your organization name
+    run: 
+      ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+      sources add
+      -source "https://nuget.pkg.github.com/<OWNER>/index.json"
+      -storepasswordincleartext
+      -name "GitHub"
+      -username "<OWNER>"
+      -password "${{ secrets.GITHUB_TOKEN }}"
+
+  # Omit this step if you're using manifests
+  - name: 'vcpkg package restore'
+    shell: 'bash'
+    run: 
+      ./vcpkg/vcpkg install opencv boost eigen3 glew --triplet ${{ matrix.triplet }}
+
+  - name: Add MSBuild to PATH
+    uses: microsoft/setup-msbuild@v1.0.2
+      
+    # - name: Build through Run bat script on PowerShell
+    # working-directory: ${{env.GITHUB_WORKSPACE}}
+    # # Add additional options to the MSBuild command line here (like platform or verbosity level).
+    # # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+    # shell: pwsh
+    # run: setx MACHINE Brand1 /m
+    # - name: Install packages and dependencies
+    #   run: |
+    #     bootstrap-vcpkg
+    #     vcpkg install opencv boost eigen3 glew
+
+  - name: set through PowerShell
+    working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+    shell: pwsh
+    run: setx VCPKG_ROOT C:\vcpkg\ /m
+    
+  - name: set on PowerShell
+    working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+    shell: pwsh
+    run: setx VCPKG_DEFAULT_TRIPLET x64 system /m
+    
+  - name: Build through Run bat script on PowerShell
+    working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+    shell: pwsh
+    run: .\Build.bat 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,10 @@
+name: test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 # actions.yaml
 #
 # In this example, vcpkg has been added as a submodule (`git submodule add https://github.com/Microsoft/vcpkg`).


### PR DESCRIPTION
At the moment Windows  build is not working and takes a long time, 1hour+. Issue is that set VCPKG_ROOT variable won't be detected by Build.bat.

Ubuntu and macOS works as planned.